### PR TITLE
Fix javascript error tests

### DIFF
--- a/features/step_definitions/javascript_error_steps.rb
+++ b/features/step_definitions/javascript_error_steps.rb
@@ -6,7 +6,8 @@ Given(/^I am on the home page$/) do
 end
 
 When(/^I go to the JavaScript error page$/) do
-  expect { @app.javascript_error_page.load }.to raise_error(Capybara::Poltergeist::JavascriptError)
+  @app.javascript_error_page.load
+  expect(errors).not_to be_empty
 end
 
 Then(/^It should show we have an error$/) do
@@ -23,7 +24,8 @@ Given(/^I'm at the home page$/) do
 end
 
 When(/^I navigate to the JavaScript error page$/) do
-  expect { visit('/jserror') }.to raise_error(Capybara::Poltergeist::JavascriptError)
+  visit('/jserror')
+  expect(errors).not_to be_empty
 end
 
 Then(/^I should see we have an error$/) do
@@ -31,4 +33,13 @@ Then(/^I should see we have an error$/) do
   # block us from continuing. However the scenario reads better if we can break
   # it down.
   true
+end
+
+def errors
+  raise 'Checking for JavaScript errors is only supported by Chrome' unless Capybara.current_driver == :chrome
+
+  page.driver.browser.manage.logs.get(:browser)
+      .select { |e| e.level == 'SEVERE' && e.message }
+      .map(&:message)
+      .to_a
 end


### PR DESCRIPTION
The javascript error tests only worked if you were using Phantomjs for the browser (and therefore the poltergiest Driver).

Quke has removed support for Phantomjs so we can no longer rely on it for an example of testing for JavaScript errors.

This change updates the example to use one that relies on Chrome being used as the driver. Again support is not universal or consistent.