### PR TITLE
Fix request tests

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -1,0 +1,8 @@
+# Local
+app_host: "http://localhost:4567"
+driver: chrome
+headless: true
+stop_on_error: false
+display_failures: false
+max_wait_time: 5
+user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,3 @@ chromedriver.log
 # Capybara related artifacts
 capybara-*.html
 output.html
-
-# Ignore your project specific .config.yml config files
-*.config.yml


### PR DESCRIPTION
The request tests assume that the user agent will be specified in the config file, and then check we get a matching value.

However for this to work anyone running this project needed to remember to add the expected value to the `.config.yml` they created locally.

In hindsight the easiest way to resolve the issue and make things simpler going forward was to add a correctly setup `.config.yml` file to the project.