### PR TITLE
Add support for custom config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ chromedriver.log
 # Capybara related artifacts
 capybara-*.html
 output.html
+
+# Local testing config files
+.config.*.yml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ bundle install
 
 You can figure out how the project runs using [Quke config files](https://github.com/DEFRA/quke#configuration). This project comes with an existing `.config.yml` file setup to allow these tests to pass.
 
-Feel free to amend the values in `.config.yml` to see how they effect the way Quke runs.
+### Experimenting & testing
+
+You can amend the values in `.config.yml` to see how they effect the way Quke runs or alternatively create your own, for example `.config.test.yml`. If you stick to the convention of `.config.[my name].yml` [Git](https://git-scm.com/) will ignore your file which means you can put whatever you like in them and not risk the content being committed to source control!
 
 ## Setup
 


### PR DESCRIPTION
Now we have added `.config.yml` to source control, any changes made to it will be picked up by git. To support running the tests with different config eg changing the driver from Chrome to Firefox, it'd be cleaner to do it in a separate file.

So this change adds an entry to gitignore to support this, and a brief explanation to the README that explains how to do it.