### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ git:
 before_install:
   - export TZ=UTC
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+
+before_script:
   - bundle exec rake run
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ git:
 before_install:
   - export TZ=UTC
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
-  - ruby demo_app/app.rb
+  - bundle exec rake run
 
 script:
   - bundle exec quke

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# The following options are needed to support headless chrome testing
+dist: trusty
+addons:
+  chrome: stable
+
+language: ruby
+rvm: 2.4.2
+cache: bundler
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+before_install:
+  - export TZ=UTC
+  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+  - ruby demo_app/app.rb
+
+script:
+  - bundle exec quke

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
 
 before_script:
-  - bundle exec rake run
+  - nohup bundle exec rake run > nohup.out 2>&1 &
 
 script:
   - bundle exec quke

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Quke example
 
+[![Build Status](https://travis-ci.com/Cruikshanks/quke-example.svg?branch=master)](https://travis-ci.com/Cruikshanks/quke-example)
+
 This repo serves as an example [Quke](https://github.com/Defra/quke) project. Refer to it for examples on how to setup your own projects, and how to use either Capybara or SitePrism in your steps to interact with a web page.
 
 **Please note**. The one exception is the [demo_app](app) folder. The tests in this example run against a dummy web site whose code lives in this folder. We put it here so we are not dependent on an external site nor an internet connection in order for the examples to work.


### PR DESCRIPTION
It would be a great test of Quke if we could actually check that as we make changes to the gem we don't break our example/test project which relies on it.

So this change updates the project to support running the scenarios in [Travis-CI](https://travis-ci.com).