### PR TITLE
Add rubocop and fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
 
 before_script:
+  - bundle exec rubocop
   - nohup bundle exec rake run > nohup.out 2>&1 &
 
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'quke',
@@ -19,7 +21,7 @@ gem 'rake'
 gem 'sinatra'
 
 # This groups covers gems which should be installed if you are actively working
-# on Quke-example itself.
+# on quke-example itself.
 group :development do
   # To enable reloading of the app whilst working on it you can use Rerun
   # https://github.com/alexch/rerun
@@ -28,4 +30,5 @@ group :development do
   # There is also a custom rake task as part of Quke to launch the demo app
   # which will use rerun if installed `bundle exec rake run`
   gem 'rerun'
+  gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
     backports (3.15.0)
     browserstack-local (1.3.0)
     builder (3.2.3)
@@ -50,6 +51,7 @@ GEM
     diff-lcs (1.3)
     ffi (1.10.0)
     gherkin (5.1.0)
+    jaro_winkler (1.5.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -63,12 +65,16 @@ GEM
     mustermann (1.0.3)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
     public_suffix (3.1.1)
     rack (2.0.7)
     rack-protection (2.0.5)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -80,6 +86,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    rubocop (0.74.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
     selenium-webdriver (3.142.3)
@@ -96,6 +110,7 @@ GEM
       site_prism-all_there (~> 0.2.0)
     site_prism-all_there (0.2.1)
     tilt (2.0.9)
+    unicode-display_width (1.6.0)
     webdrivers (4.1.2)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
@@ -110,6 +125,7 @@ DEPENDENCIES
   quke!
   rake
   rerun
+  rubocop
   sinatra
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 desc 'Runs the demo web app (see :run)'
-task default: %w(run)
+task default: %w[run]
 
 desc 'Run demo web app (is the website against which the examples run)'
 task :run do
@@ -15,8 +17,8 @@ task :clean do
   File.delete(*Dir.glob('tmp/capybara-*.html'))
 end
 
-require "quke"
+require 'quke'
 
 # Add support to quke to run the webdriver rake tasks
 # https://github.com/titusfortner/webdrivers#rake-tasks
-load "quke/Rakefile"
+load 'quke/Rakefile'

--- a/demo_app/app.rb
+++ b/demo_app/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra'
 
 # This require was only added to stop this warning from appearing in the output
@@ -15,7 +17,7 @@ configure do
 
   # It's not critical for this app, but best practise is to secure your session
   # with a secret key, and this also stops Sinatra complaining!
-  set :session_secret, SECRET ||= 'super secret'.freeze
+  set :session_secret, SECRET ||= 'super secret'
 end
 
 get '/' do
@@ -81,6 +83,7 @@ end
 
 get '/jserror' do
   @title = 'JavaScript error'
-  @results = "Open your browser's dev tools, specifically the JavaScript console. You should see an error!"
+  @results = "Open your browser's dev tools, specifically the JavaScript"\
+             'console. You should see an error!'
   erb :javascript_error
 end

--- a/demo_app/config.ru
+++ b/demo_app/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The config.ru file allows us to use any Rack handler, which in our case is
 # [Thin](https://github.com/macournoyer/thin) to start the app, rather than
 # relying on Sinatra magic.

--- a/features/page_objects/app.rb
+++ b/features/page_objects/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Represents all pages in the application. Was created to avoid needing to
 # create individual instances of each page throughout the steps.
 # https://github.com/natritmeyer/site_prism#epilogue

--- a/features/page_objects/button_page.rb
+++ b/features/page_objects/button_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Radio button page
 class RadioButtonPage < SitePrism::Page
   set_url '/radiobutton'

--- a/features/page_objects/css_selectors_page.rb
+++ b/features/page_objects/css_selectors_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # CSS selectors page
 class CssSelectorsPage < SitePrism::Page
   set_url '/cssselector'

--- a/features/page_objects/home_page.rb
+++ b/features/page_objects/home_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Home page
 class HomePage < SitePrism::Page
   set_url '/'

--- a/features/page_objects/javascript_error_page.rb
+++ b/features/page_objects/javascript_error_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # JavaScript error page
 class JavascriptErrorPage < SitePrism::Page
   set_url '/jserror'

--- a/features/page_objects/request_details_page.rb
+++ b/features/page_objects/request_details_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Request details page
 class RequestDetailsPage < SitePrism::Page
   set_url '/request'

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Search page
 class SearchPage < SitePrism::Page
   set_url '/search'

--- a/features/step_definitions/css_selector_steps.rb
+++ b/features/step_definitions/css_selector_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The following steps use the page objects to drive the browser
 # -------------------------------------------------------------
 

--- a/features/step_definitions/javascript_error_steps.rb
+++ b/features/step_definitions/javascript_error_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The following steps use the page objects to drive the browser
 Given(/^I am on the home page$/) do
   @app = App.new
@@ -36,7 +38,9 @@ Then(/^I should see we have an error$/) do
 end
 
 def errors
-  raise 'Checking for JavaScript errors is only supported by Chrome' unless Capybara.current_driver == :chrome
+  if Capybara.current_driver == :chrome
+    raise 'Checking for JavaScript errors is only supported by Chrome'
+  end
 
   page.driver.browser.manage.logs.get(:browser)
       .select { |e| e.level == 'SEVERE' && e.message }

--- a/features/step_definitions/radio_button_steps.rb
+++ b/features/step_definitions/radio_button_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The following steps use the page objects to drive the browser
 Given(/^I am on the radio button page$/) do
   @app = App.new

--- a/features/step_definitions/request_details_steps.rb
+++ b/features/step_definitions/request_details_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The following steps use the page objects to drive the browser
 Given(/^I am on the request details page$/) do
   @app = App.new

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The following steps use the page objects to drive the browser
 Given(/^I am on the search page$/) do
   @app = App.new


### PR DESCRIPTION
Part of making this a good example project is ensuring the code it contains follows the current community conventions for ruby.

Hence this change which adds [rubocop](https://github.com/rubocop-hq/rubocop) to the project, and fixes all existing issues found.