### PR TITLE
Prepare for move to Defra

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,8 @@
-The MIT License (MIT)
+The Open Government Licence (OGL) Version 3
 
-Copyright (c) 2017 Alan Cruikshanks
+Copyright (c) 2019 Environment Agency
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Quke example
 
 [![Build Status](https://travis-ci.com/DEFRA/quke-example.svg?branch=master)](https://travis-ci.com/DEFRA/quke-example)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 This repo serves as an example [Quke](https://github.com/Defra/quke) project. Refer to it for examples on how to setup your own projects, and how to use either Capybara or SitePrism in your steps to interact with a web page.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quke example
 
-[![Build Status](https://travis-ci.com/Cruikshanks/quke-example.svg?branch=master)](https://travis-ci.com/Cruikshanks/quke-example)
+[![Build Status](https://travis-ci.com/DEFRA/quke-example.svg?branch=master)](https://travis-ci.com/DEFRA/quke-example)
 
 This repo serves as an example [Quke](https://github.com/Defra/quke) project. Refer to it for examples on how to setup your own projects, and how to use either Capybara or SitePrism in your steps to interact with a web page.
 
@@ -17,7 +17,7 @@ The rest of the pre-requisites are the same as those for [Quke](https://github.c
 First clone the repository and then drop into your new local repo
 
 ```bash
-git clone https://github.com/Cruikshanks/quke-example.git && cd quke-example
+git clone https://github.com/DEFRA/quke-example.git && cd quke-example
 ```
 
 Next download and install the dependencies

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ All contributions should be submitted via a pull request.
 
 ## License
 
-This information is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
-> If you don't add a license it's neither free or open
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+> Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/demo_app/views/layout.erb
+++ b/demo_app/views/layout.erb
@@ -7,7 +7,7 @@
   <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
   <meta name="description" content="The Quke demo web site" />
-  <meta name="author" content="Alan Cruikshanks" />
+  <meta name="author" content="Defra" />
 
   <!-- Icon for Quke was created by combining the following images -->
   <!-- http://cliparts.co/clipart/2895339 -->


### PR DESCRIPTION
As the defacto example for the Defra [Quke](https://github.com/DEFRA/quke) framework and with working CI implemented, we are now moving this out of its holding place against a personal account and into the Defra organisation.

Main change is the LICENSE, and the bottom section of the README to match in with our normal standards.