### PR TITLE
Fix rubocop errors in the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 # The following options are needed to support headless chrome testing
 dist: trusty
+
 addons:
   chrome: stable
 
 language: ruby
 rvm: 2.4.2
 cache: bundler
+
 # Travis CI clones repositories to a depth of 50 commits, which is only really
 # useful if you are performing git operations.
 # https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
@@ -14,11 +16,9 @@ git:
 
 before_install:
   - export TZ=UTC
-  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
-  - gem install rubocop --no-rdoc --no-ri
+  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
 
 before_script:
-  - rubocop
   - nohup bundle exec rake run > nohup.out 2>&1 &
 
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/quke
-  revision: 89508bc4be7d6e16761d93b1fae0ec749fd8b347
+  revision: 10fcfcf1e337f5aaab7cce5fb5a45ca3d3f566ba
   branch: master
   specs:
     quke (0.10.0)
@@ -18,7 +18,7 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    backports (3.15.0)
+    backports (3.17.0)
     browserstack-local (1.3.0)
     builder (3.2.4)
     capybara (3.31.0)
@@ -48,14 +48,14 @@ GEM
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
     gherkin (5.1.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     multi_json (1.14.1)
     multi_test (0.1.2)
     mustermann (1.0.3)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     public_suffix (4.0.3)
     quke_demo_app (0.2.0)
@@ -67,12 +67,12 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.1)
-    regexp_parser (1.6.0)
+    regexp_parser (1.7.0)
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubyzip (2.1.0)
+    rubyzip (2.2.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -81,10 +81,10 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.7)
       tilt (~> 2.0)
-    site_prism (3.4.1)
+    site_prism (3.4.2)
       addressable (~> 2.5)
       capybara (~> 3.3)
-      site_prism-all_there (~> 0.3)
+      site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
     thor (0.20.3)
     tilt (2.0.9)


### PR DESCRIPTION
Not exactly sure why I thought to run rubocop on a quke based project. Probably more I just copied and pasted the travis config from somewhere that does.

So this change removes the call to rubocop plus the odd little tidy up.