### PR TITLE
Remove duplicate bundle install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      # Performs a clean installation of all dependencies in the `Gemfile.lock` file
-      - name: Install dependencies
-        run: bundle install
-
       # Start our test app which we use to run our example scenarios against
       - name: Start example app
         run: |


### PR DESCRIPTION
Spotted after the fact that we had an unnecessary call to `bundle install`.

The ruby setup action already does this with its `bundler-cache: true` so there is no need for us to repeat the command.